### PR TITLE
bundle install using the correct rvm environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
 before_script:
   - git config --global user.email "johndoe@example.com"
   - git config --global user.name "John Doe"
-  - echo 'export rvm_ignore_gemset_flag=1' >> $HOME/.rvmrc
-  - export rvm_ignore_gemset_flag=1
+  - echo 'export rvm_ignore_gemsets_flag=1' >> $HOME/.rvmrc
+  - export rvm_ignore_gemsets_flag=1

--- a/README.md
+++ b/README.md
@@ -45,14 +45,7 @@ This will create a Rails 4.1.8 app with Ruby 2.1.5. This script creates a new gi
 
 ### RVM
 
-If you're using RVM, create and use a gemset (with the project name) before running PAH:
-
-```bash
-$ rvm use 2.1.5@projectname --create
-$ pah projectname
-```
-
-PAH automatically create the .ruby-version and .ruby-gemset files.
+If you're using RVM, pah will create a gemset with the same name of your project
 
 ## Versioning
 

--- a/lib/pah/templates/gems.rb
+++ b/lib/pah/templates/gems.rb
@@ -7,24 +7,41 @@ module Pah
         gsub_file 'Gemfile', /RUBY_VERSION/, ::Pah::RUBY_VERSION
         gsub_file 'Gemfile', /RAILS_VERSION/, ::Pah::RAILS_VERSION
 
+
         begin
           require 'bundler'
         rescue LoadError
           # Install bundler if needed
-          unless run 'gem install bundler --no-ri --no-rdoc'
+          unless run_with_rvm_env_if_possible 'gem install bundler --no-ri --no-rdoc'
             puts 'Error installing bundler, will attempt to continue'
           end
           require 'bundler'
         end
 
         # Install all other gems needed from Gemfile
-        unless run 'bundle install --jobs=4'
+        unless run_with_rvm_env_if_possible 'bundle install --jobs=4'
           puts 'Error installing gems, aborting'
           exit 1
         end
 
         git add: 'Gemfile*'
         git_commit 'Add Gemfile and Gemfile.lock.'
+      end
+
+      def run_with_rvm_env_if_possible(command)
+        if rvm_installed?
+          current_ruby = ::Pah::RUBY_VERSION
+          current_gemset = ::Pah.configuration.app_name
+          use_current_ruby_script = %{[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" && rvm use ruby-#{current_ruby}@#{current_gemset} --create}
+          run "/bin/bash --login -c '#{use_current_ruby_script} && #{command}'"
+        else
+          run command
+        end
+      end
+
+      def rvm_installed?
+        @_rvm_installed = `which rvm`.present? if @_rvm_installed.nil?
+        @_rvm_installed
       end
     end
   end


### PR DESCRIPTION
At the moment, pah is bundle install'ing and using the default ruby version which the command was started. 
So when you enter into the generated project the console outputs that the gemset is created because the `.ruby-version` and `.ruby-gemset` exist. And then you have to bundle install again to get the dependencies for this new environment.
This PR fixes it manually creating the gemset, *and* running the bundle install using it.

How to test:
```sh
cd path/to/pah
git pull this patch
rvm gemset delete test_pah # delete any previous created gemset
bundle exec ./bin/pah ~/test_pah # run pah using these changes
cd ~/test_pah
rails s # should not claim about missing gems
```