### PR TITLE
Fix rvm_ignore_gemsets_flag option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
 before_script:
   - git config --global user.email "johndoe@example.com"
   - git config --global user.name "John Doe"
-  - echo 'export rvm_ignore_gemset_flag=1' >> $HOME/.rvmrc
-  - export rvm_ignore_gemset_flag=1
+  - echo 'export rvm_ignore_gemsets_flag=1' >> $HOME/.rvmrc
+  - export rvm_ignore_gemsets_flag=1


### PR DESCRIPTION
Per documentation https://rvm.io/gemsets/ignoring the correct name is `rvm_ignore_gemsets_flag` not `rvm_ignore_gemset_flag`