### PR TITLE
[workaround] Update jumpup heroku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### improvements
 
 ### bug fixes
+- [Workaround] Update jumpup-heroku version to use fixed master branch
 
 ## 0.0.21 (March 19,2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### improvements
 
 ### bug fixes
-- [Workaround] Update jumpup-heroku version to use fixed master branch
+- Changed jumpup-heroku version to 0.0.6 [[GH-475](https://github.com/Helabs/pah/issues/475)]
 
 ## 0.0.21 (March 19,2015)
 

--- a/lib/pah/files/Gemfile
+++ b/lib/pah/files/Gemfile
@@ -32,7 +32,7 @@ end
 group :development do
   gem 'foreman',              '0.77.0'
   gem 'jumpup',               '0.0.8'
-  gem 'jumpup-heroku',        github: 'Helabs/jumpup-heroku'
+  gem 'jumpup-heroku',        '0.0.6'
   gem 'better_errors',        '2.1.1'
   gem 'binding_of_caller',    '0.7.2'
   gem 'letter_opener',        '1.3.0'

--- a/lib/pah/files/Gemfile
+++ b/lib/pah/files/Gemfile
@@ -32,7 +32,7 @@ end
 group :development do
   gem 'foreman',              '0.77.0'
   gem 'jumpup',               '0.0.8'
-  gem 'jumpup-heroku',        '0.0.5'
+  gem 'jumpup-heroku',        github: 'Helabs/jumpup-heroku'
   gem 'better_errors',        '2.1.1'
   gem 'binding_of_caller',    '0.7.2'
   gem 'letter_opener',        '1.3.0'


### PR DESCRIPTION
This PR fix pah, but we need a new jumpup-heroku release to set the gem version.