### PR TITLE
Change NewRelic Add-on plan from stark to wayne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### improvements
 
 ### bug fixes
+- Changed NewRelic Add-on plan from stark to wayne
 
 ## 0.0.22 (April 20,2015)
 

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -46,7 +46,7 @@ Feature: Run without errors
       """
     Then the stdout should contain:
       """
-      running heroku addons:add newrelic:stark --app myapponheroku
+      running heroku addons:add newrelic:wayne --app myapponheroku
       """
     Then the stdout should contain:
       """

--- a/lib/pah/templates/heroku.rb
+++ b/lib/pah/templates/heroku.rb
@@ -1,6 +1,6 @@
 class HerokuApp < Rails::Generators::AppGenerator
   DEFAULT_ADDONS = %w(heroku-postgresql:dev logentries
-                      mandrill:starter rollbar newrelic:stark librato)
+                      mandrill:starter rollbar newrelic:wayne librato)
 
   attr_reader :name, :description, :config
 


### PR DESCRIPTION
When I tried to create a project, I received the following error message:

> Adding heroku addon [newrelic:stark] to 'night-blog'.
! No such add-on plan.

Probably the **Stark** plan was removed. So I look at New Relic [Add-on](https://addons.heroku.com/newrelic#wayne) plans and **Wayne** is the free plan currently.

This PR changes the plan :smile: