### PR TITLE
Change command that adds Heroku add-ons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### features
 
 ### improvements
+- Change command that add Heroku add-ons from `addons:add` to `addons:create`
 
 ### bug fixes
 - Changed NewRelic Add-on plan from stark to wayne

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -30,27 +30,27 @@ Feature: Run without errors
       """
     Then the stdout should contain:
       """
-      running heroku addons:add heroku-postgresql:dev --app myapponheroku
+      running heroku addons:create heroku-postgresql:dev --app myapponheroku
       """
     Then the stdout should contain:
       """
-      running heroku addons:add logentries --app myapponheroku
+      running heroku addons:create logentries --app myapponheroku
       """
     Then the stdout should contain:
       """
-      running heroku addons:add mandrill:starter --app myapponheroku
+      running heroku addons:create mandrill:starter --app myapponheroku
       """
     Then the stdout should contain:
       """
-      running heroku addons:add rollbar --app myapponheroku
+      running heroku addons:create rollbar --app myapponheroku
       """
     Then the stdout should contain:
       """
-      running heroku addons:add newrelic:wayne --app myapponheroku
+      running heroku addons:create newrelic:wayne --app myapponheroku
       """
     Then the stdout should contain:
       """
-      running heroku addons:add librato --app myapponheroku
+      running heroku addons:create librato --app myapponheroku
       """
     Then the stdout should contain:
       """

--- a/features/support/bin/heroku
+++ b/features/support/bin/heroku
@@ -12,9 +12,9 @@ class Heroku < Thor
     puts "running heroku config:set #{config.join(' ')}"
   end
 
-  desc 'addons:add', 'stub of heroku addons:add'
-  define_method 'addons:add' do |*addon|
-    puts "running heroku addons:add #{addon.join(' ')}"
+  desc 'addons:create', 'stub of heroku addons:create'
+  define_method 'addons:create' do |*addon|
+    puts "running heroku addons:create #{addon.join(' ')}"
   end
 
   desc 'domains:add', 'stub of heroku domains:add'

--- a/lib/pah/templates/heroku.rb
+++ b/lib/pah/templates/heroku.rb
@@ -35,7 +35,7 @@ class HerokuApp < Rails::Generators::AppGenerator
 
   def add_heroku_addon(addon)
     say "Adding heroku addon [#{addon}] to '#{name}'.".green
-    run "heroku addons:add #{addon} --app #{name}"
+    run "heroku addons:create #{addon} --app #{name}"
   end
 
   def add_canonical_domain(domain)


### PR DESCRIPTION
This PR fixes the following message:

> WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead.