### PR TITLE
Set --at param on pg:backups schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove rack-timeout (ref.: https://github.com/heroku/rack-timeout/issues/73#issuecomment-89170627)
 
 ### bug fixes
+- Fix `pg:backups schedule` task which requires --at param
 
 ## 0.0.23 (June 12,2015)
 

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -58,7 +58,7 @@ Feature: Run without errors
       """
     Then the stdout should contain:
       """
-      running heroku pg:backups schedule DATABASE_URL --app myapponheroku
+      running heroku pg:backups schedule DATABASE_URL --at 02:00 America/Sao_Paulo --app myapponheroku
       """
     Then the output should contain:
       """

--- a/lib/pah/templates/heroku.rb
+++ b/lib/pah/templates/heroku.rb
@@ -57,7 +57,7 @@ class HerokuApp < Rails::Generators::AppGenerator
   end
 
   def schedule_backup
-    run "heroku pg:backups schedule DATABASE_URL --app #{name}"
+    run "heroku pg:backups schedule DATABASE_URL --at '02:00 America/Sao_Paulo' --app #{name}"
   end
 
   def open


### PR DESCRIPTION
It fix the following issue:
```
Adding Heroku git remote for deploy to 'MYPROJECT'.
 !    You must specifiy a time to schedule backups, i.e --at '04:00 UTC'
/Users/user/projects/pah/lib/pah/templates/heroku.rb:73:in `run': Error while running heroku pg:backups schedule DATABASE_URL --app MYPROJECT (RuntimeError)
```