### PR TITLE
Remove web-console gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.0.25 (Unreleased)
+- Remove web-console gem
 
 ### features
 

--- a/lib/pah/files/Gemfile
+++ b/lib/pah/files/Gemfile
@@ -58,6 +58,5 @@ group :development, :test do
   gem 'awesome_print',         '1.6.1'
   gem 'spring-commands-rspec', '1.0.4'
   gem 'byebug',                '5.0.0'
-  gem 'web-console',           '2.2.1'
   gem 'spring',                '1.3.6'
 end


### PR DESCRIPTION
This gem was in the development/test group in the Gemfile and was affecting the speed of the controller specs testing sad paths. The tests in my project ran at around 6 minutes and after removing the gem is now running at around 3:30 ~ 3:40 minutes.

Since no one seems to know the existence of this gem and use it. I suggest we remove it from the default Gemfile on pah.