### PR TITLE
Update gem rollbar to 2.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.0.26 (Unreleased)
 - Fix Heroku sharing command, changed from sharing:add to access:add
+- Changed Rollbar version to 2.11.3
 
 ## 0.0.25
 - Remove web-console gem

--- a/features/rails_works.feature
+++ b/features/rails_works.feature
@@ -7,6 +7,7 @@ Feature: Rails works
   Scenario: The rails works
     When I run `cp -r myapp myapp_with_controller`
     And I cd to "myapp_with_controller"
+    And I run `ruby -e "Bundler.with_clean_env { system 'bundle exec spring stop' }"`
     And I run `ruby -e "Bundler.with_clean_env { system 'bundle exec rails g controller welcome index' }"`
     And I run `ruby -e "Bundler.with_clean_env { system 'bundle exec rails s' }"` interactively
     And I run `ruby -e "Bundler.with_clean_env { system 'sleep 15' }"`

--- a/lib/pah/files/Gemfile
+++ b/lib/pah/files/Gemfile
@@ -19,7 +19,7 @@ gem 'neat',                   '1.7.2'
 gem 'bitters',                '1.1.0'
 gem 'refills',                '0.1.0'
 gem 'normalize-rails',        '3.0.3'
-gem 'rollbar',                '2.7.0'
+gem 'rollbar',                '2.11.3'
 
 group :production, :staging do
   gem 'rails_12factor',       '0.0.3'


### PR DESCRIPTION
update fix bug undefined method 'split' for nil:Nilclass (NoMethodError)